### PR TITLE
fixes for os prov, HA server restart

### DIFF
--- a/hpcm_pbspro_connector/README
+++ b/hpcm_pbspro_connector/README
@@ -41,6 +41,13 @@ Notes
    (README file will need to specify the requirement that the PBS client commands are to be installed on the admin node.
    o   qmgr -c "set server managers += <site_user_account>" - - optional instructions)
    (example user admin1 logged into the GUI and he is added to the managers list then he is allowed to make changes to the scheduler)
+   mention os provisioning changes. user need to supply kernal, roofs type and node type via environment variable (e.g. PBS_HPCM_KERNAL) in qsub. also pbsnodes will have resources_available.kernal=<list of kernal> fetched by using a command as part of provisioning setup.
+   list of nodes: compute, ice-compute, leader list of rootfs type: disk, ramfs
+   a hook will run when vnode is restarted to get list of kernals which is set as a list to resources_available.kernal. periodically this list is refreshed. kernal as a custom string-array resources is set up.
+   requires pwd-less ssh from server to admin
+   Added support for PBS HA.
+   - Admin can start/stop services on primary or secondary or both.
+   - A configuration file in json format need to be imported to the OS provisioning hook. Update name of admin node in the config file. 
 
    Install option 1: Using dedicated node
    - PBS Professional Server/Scheduler is installed on the Service Node

--- a/hpcm_pbspro_connector/bin/hpcm_pbs_node_provision
+++ b/hpcm_pbspro_connector/bin/hpcm_pbs_node_provision
@@ -98,6 +98,7 @@ else
     echo "Creating cmu_provision hook..."
     ${PBS_EXEC}/bin/qmgr -c "create hook cmu_provision event = provision"
     ${PBS_EXEC}/bin/qmgr -c "import hook cmu_provision application/x-python default /opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_os_provision_hook.py"
+    ${PBS_EXEC}/bin/qmgr -c "import hook cmu_provision application/x-config default /opt/clmgr/contrib/hpcm_pbspro_connector/etc/hpcm_pbs_os_provision_hook.json"
     echo "....... DONE"
 fi
 

--- a/hpcm_pbspro_connector/bin/hpcm_pbs_os_provision_hook.py
+++ b/hpcm_pbspro_connector/bin/hpcm_pbs_os_provision_hook.py
@@ -43,14 +43,46 @@ e = pbs.event()
 vnode = e.vnode
 aoe = e.aoe
 
+# event=provision runs only on server. user can request an aoe to be provisioned with a kernal of his choice on either disk or tmpfs and on a flat node, or ICE etc.
+# provisioning CLI in HPCM requires more than AOE and Vnode. It requires kernal, rootfs type and node type. Based on this info, right image is provisioned on right node. So user will have to supply  this additional information. Since support by PBS in this regard is not possible in limited time, a workaround is provided.
+
+# Provision hook will run on PBS Server but provisioning is started from admin node
+# Check for admin node? Read from json config file.
+
+kernel = os.environ["PBS_HPCM_KERNAL"]
+prov   = os.environ["PBS_HPCM_PROVTYPE"].lower()
+rootfs = os.environ["PBS_HPCM_ROOTFS"].lower()
+
 pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: Env = %s" % repr(os.environ))
 pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: PBS Node = %s" % vnode)
 pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: AOE = %s" % aoe)
+pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: PROVISION TYPE = %s" % prov)
+pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: KERNAL = %s" % kernal)
+pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: ROOTFS = %s" % rootfs)
 
-ret = os.system("/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_provision.sh " + aoe + " " + vnode)
-if ret != 0:
-    pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: Failed - retcode = %s" % str(ret))
-    e.reject("Reboot provisioning failed", ret)
+if 'PBS_HOOK_CONFIG_FILE' in os.environ:
+    import json
+    config_file = os.environ["PBS_HOOK_CONFIG_FILE"]
+    #pbs.logmsg(pbs.EVENT_DEBUG, "%s: Config file is %s" % (caller_name(), config_file))
+    config = json.load(open(config_file, 'r'), object_hook=decode_dict)
+
+server = pbs.server().name
+admin = config['admin-node']
+
+pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: server name = %s" % server)
+pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: admin node = %s" % admin)
+
+if admin == server:
+    ret = os.system("/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_provision.sh " + aoe + " " + vnode + " " + kernal + " " + prov + " " + rootfs)
+    if ret != 0:
+        pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: Failed - retcode = %s" % str(ret))
+        e.reject("Reboot provisioning failed", ret)
+    else:
+        e.accept(0)
 else:
-    os.system("/opt/clmgr/bin/cmu_power -p BOOT -n " + vnode)
-    e.accept(0)
+    ret = os.system("ssh ${admin} /opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_provision.sh " + aoe + " " + vnode + " " + kernal + " " + prov + " " + rootfs)
+    if ret != 0:
+        pbs.logmsg(pbs.LOG_DEBUG, "PROVISIONING: Failed - retcode = %s" % str(ret))
+        e.reject("Reboot provisioning failed", ret)
+    else:
+        e.accept(0)

--- a/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler
+++ b/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler
@@ -61,11 +61,11 @@ CMU_PATH=/opt/cmu/bin
 # Simple Usage statement
 Usage() {
     cat <<EOF
-Usage: `basename $0` action
+Usage: `basename $0` action server
 
 action can be start, stop or restart
 
-nodelist can be a space-separated list or a file
+server can be primary or secondary. If not provided, PBS service on both nodes will be acted upon.
 
 EOF
     exit 0
@@ -80,20 +80,49 @@ done
 node=`hostname`
 
 # If node is PBS_SERVER proceed with case statement logic
-# If node is _not_ the PBS_SERVER then echo simple error message
+# If node is _not_ the PBS_SERVER then check which server to proceed with
+# If server not provided then proceed with both servers
 if [ "${node}" == "${PBS_SERVER}" ]; then
     case $1 in
         *stop)       /etc/init.d/pbs stop ;;
         *restart)    /etc/init.d/pbs restart ;;
         *start)      /etc/init.d/pbs start ;;
     esac
+elif [ -n "$2" ]; then
+    if [ "$2" == "primary" ]; then
+        case $1 in
+            *stop)       echo "Stopping Primary PBS Server/Scheduler on ${PBS_PRIMARY}"
+                         ssh ${PBS_PRIMARY} /etc/init.d/pbs stop ;;
+            *restart)    echo "Restart Primary PBS Server/Scheduler on ${PBS_PRIMARY}"
+                         ssh ${PBS_PRIMARY} /etc/init.d/pbs restart ;;
+            *start)      echo "Starting Primary PBS Server/Scheduler on ${PBS_PRIMARY}"
+                         ssh ${PBS_PRIMARY} /etc/init.d/pbs start ;;
+        esac
+    fi
+
+    if [ "$2" == "secondary" ]; then
+        case $1 in
+            *stop)       echo "Stopping Secondary PBS Server/Scheduler on ${PBS_SECONDARY}"
+                         ssh ${PBS_SECONDARY} /etc/init.d/pbs stop ;;
+            *restart)    echo "Restart Secondary PBS Server/Scheduler on ${PBS_SECONDARY}"
+                         ssh ${PBS_SECONDARY} /etc/init.d/pbs restart ;;
+            *start)      echo "Starting Secondary PBS Server/Scheduler on ${PBS_SECONDARY}"
+                         ssh ${PBS_SECONDARY} /etc/init.d/pbs start ;;
+        esac
+    fi
 else
     case $1 in
-        *stop)       echo "Stopping PBS Server/Scheduler on ${PBS_SERVER}"
-                     ssh ${PBS_SERVER} /etc/init.d/pbs stop ;;
-        *restart)    echo "Restart PBS Server/Scheduler on ${PBS_SERVER}"
-                     ssh ${PBS_SERVER} /etc/init.d/pbs restart ;;
-        *start)      echo "Starting PBS Server/Scheduler on ${PBS_SERVER}"
-                     ssh ${PBS_SERVER} /etc/init.d/pbs start ;;
+        *stop)       echo "Stopping Primary PBS Server/Scheduler on ${PBS_PRIMARY}"
+                     ssh ${PBS_PRIMARY} /etc/init.d/pbs stop ;;
+                     echo "Stopping Secondary PBS Server/Scheduler on ${PBS_SECONDARY}"
+                     ssh ${PBS_SECONDARY} /etc/init.d/pbs stop ;;
+        *restart)    echo "Restart Primary PBS Server/Scheduler on ${PBS_PRIMARY}"
+                     ssh ${PBS_PRIMARY} /etc/init.d/pbs restart ;;
+                     echo "Restart Secondary PBS Server/Scheduler on ${PBS_SECONDARY}"
+                     ssh ${PBS_SECONDARY} /etc/init.d/pbs restart ;;
+        *start)      echo "Starting Primary PBS Server/Scheduler on ${PBS_PRIMARY}"
+                     ssh ${PBS_PRIMARY} /etc/init.d/pbs start ;;
+                     echo "Starting Secondary PBS Server/Scheduler on ${PBS_SECONDARY}"
+                     ssh ${PBS_SECONDARY} /etc/init.d/pbs start ;;
     esac
 fi

--- a/hpcm_pbspro_connector/bin/hpcm_pbs_update_imagegroup
+++ b/hpcm_pbspro_connector/bin/hpcm_pbs_update_imagegroup
@@ -63,8 +63,11 @@ echo "Updating PBS Professional Application Operating Environment (aoe) with HPC
 echo "Verifying that the cmu_provision hook is installed..."
 if [[ ! -n `ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c 'print hook cmu_provision'"` ]] ; then
     echo "cmu_provision hook will be installed..."
-    ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"create hook cmu_provision\""
+    ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"create hook cmu_provision event = provision\""
+
     ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"import hook cmu_provision application/x-python default /opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_os_provision_hook.py\""
+    ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"import hook cmu_provision application/x-config default /opt/clmgr/contrib/hpcm_pbspro_connector/etc/hpcm_pbs_os_provision_hook.json\""
+    ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"create resource kernal type=string_array,flag=h\""
 fi
 echo "....... DONE"
 echo " "
@@ -73,6 +76,7 @@ echo " "
 echo "Removing existing aoe from all nodes..."
 for node in `ssh ${PBS_SERVER} "${PBS_EXEC}/bin/pbsnodes -a | grep -e \"^[[:alnum:]]\""` ; do
     ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"unset node ${node} resources_available.aoe\""
+    ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"unset node ${node} resources_available.kernal\""
     ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"unset node ${node} current_aoe\""
 done
 echo "....... DONE"
@@ -81,9 +85,9 @@ echo " "
 # Configuring PBS Professional with HPCM configured image_groups
 echo "Configuring image_groups..."
 for image_group in `${CMU_SHOW_LOGICAL_GROUPS}`; do
-    for node in `${CMU_SHOW_LOGICAL_GROUPS} ${logical_group}`; do
+    for node in `${CMU_SHOW_LOGICAL_GROUPS} ${image_group}`; do
         if [[ -n `ssh ${PBS_SERVER} "${PBS_EXEC}/bin/pbsnodes ${node}"` ]] ; then
-            ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"set node ${node} resources_available.aoe += ${logical_group}\""
+            ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"set node ${node} resources_available.aoe += ${image_group}\""
         fi
     done
 done
@@ -93,5 +97,15 @@ for node in `ssh ${PBS_SERVER} "${PBS_EXEC}/bin/pbsnodes -a | grep -e \"^[[:alnu
     current_aoe=`${CMU_SHOW_NODES} -n ${node} -o "%l"`
     ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"set node ${node} current_aoe = ${current_aoe}\""
 done
+
+# setting kernals available.
+for kernal in `cimage --show-images | grep -v 'image:' | tr -s ' ' | sort | uniq`; do
+    for node in `${CMU_SHOW_LOGICAL_GROUPS} ${logical_group}`; do
+        if [[ -n `ssh ${PBS_SERVER} "${PBS_EXEC}/bin/pbsnodes ${node}"` ]] ; then
+            ssh ${PBS_SERVER} "${PBS_EXEC}/bin/qmgr -c \"set node ${node} resources_available.kernal += ${kernal}\""
+        fi
+    done
+done
+
 echo "....... DONE"
 echo " "

--- a/hpcm_pbspro_connector/etc/PBS_Specific_cmu_custom_menu
+++ b/hpcm_pbspro_connector/etc/PBS_Specific_cmu_custom_menu
@@ -82,10 +82,18 @@ TERMINAL;HPCM PBS Professional Connector|Configure PBS Server (qmgr);"/opt/pbs/b
 TERMINAL;HPCM PBS Professional Connector|Configure PBS Custom Resources (qmgr);"/opt/pbs/bin/qmgr"
 TERMINAL;HPCM PBS Professional Connector|Configure PBS Scheduler (sched_config);"vi /var/spool/PBS/sched_priv/sched_config ; echo \"Scheduler re-reading sched_config\" ; kill -HUP `cat /var/spool/PBS/sched_priv/sched.lock` ; echo \"Done\""
 #
-# Start/Stop PBS Server/Scheduler on head node :: Assumes PBS Server/Scheduler is running on HPCM headnode.
-SERVER;HPCM PBS Professional Connector|Restart PBS Server/Scheduler;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler restart
-SERVER;HPCM PBS Professional Connector|Stop PBS Server/Scheduler;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler stop
-SERVER;HPCM PBS Professional Connector|Start PBS Server/Scheduler;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler start
+# Start/Stop Primary PBS Server/Scheduler on head node :: Assumes PBS Server/Scheduler is running on HPCM headnode.
+SERVER;HPCM PBS Professional Connector|Restart PBS Server/Scheduler on Primary;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler restart primary
+SERVER;HPCM PBS Professional Connector|Stop Secondary PBS Server/Scheduler on Primary;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler stop primary
+SERVER;HPCM PBS Professional Connector|Start PBS Server/Scheduler on Primary;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler start primary
+# Start/Stop Secondary PBS Server/Scheduler on head node :: Assumes PBS Server/Scheduler is running on HPCM headnode.
+SERVER;HPCM PBS Professional Connector|Restart PBS Server/Scheduler on Secondary;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler restart secondary
+SERVER;HPCM PBS Professional Connector|Stop PBS Server/Scheduler on Secondary;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler stop secondary
+SERVER;HPCM PBS Professional Connector|Start PBS Server/Scheduler on Secondary;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler start secondary
+# Start/Stop Both Primary and Secondary PBS Server/Scheduler on head node :: Assumes PBS Server/Scheduler is running on HPCM headnode.
+SERVER;HPCM PBS Professional Connector|Restart PBS Server/Scheduler on both;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler restart
+SERVER;HPCM PBS Professional Connector|Stop PBS Server/Scheduler on both;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler stop
+SERVER;HPCM PBS Professional Connector|Start PBS Server/Scheduler on both;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_server_scheduler start
 #
 # Show ALL JOBS and ALL RESERVATIONS on cluster.
 SERVER;HPCM PBS Professional Connector|Show jobs;/opt/clmgr/contrib/hpcm_pbspro_connector/bin/hpcm_pbs_show_jobs

--- a/hpcm_pbspro_connector/etc/hpcm_pbs_os_provision_hook.json
+++ b/hpcm_pbspro_connector/etc/hpcm_pbs_os_provision_hook.json
@@ -1,0 +1,3 @@
+{
+    "admin-node": "admin"
+}


### PR DESCRIPTION
- os prov now requires kernel, prov type, fstype
- provisioning occurs on service node hence adding config file to read in admin node name
- restarting daemon means restarting primary and/or secondary
- readme update with values to expect for fstype, prov type